### PR TITLE
Remove kinect 2 driver from ur5 kinetic setup

### DIFF
--- a/kinetic-tams_ur5-setup+pick-place.rosinstall
+++ b/kinetic-tams_ur5-setup+pick-place.rosinstall
@@ -25,9 +25,6 @@
     uri: https://github.com/TAMS-Group/robotiq.git
     version: kinetic-devel_bluetooth
 - git:
-    local-name: upstream/iai_kinect2
-    uri: https://github.com/code-iai/iai_kinect2.git
-- git:
     local-name: upstream/apriltags_ros
     uri: https://github.com/RIVeR-Lab/apriltags_ros.git
     version: indigo-devel


### PR DESCRIPTION
The driver is often not needed and the dependencies can lead to problems when trying to build the package.